### PR TITLE
Fixed docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ import styled from 'styled-components';
 import { grid } from 'styled-components-grid';
 
 const FeaturePanel = styled`
-  ${grid()}
+  ${grid({})}
 `;
 
 const Feature = styled`


### PR DESCRIPTION
`grid` method needs an empty object, otherwise there is an error.